### PR TITLE
removed name field pattern matching

### DIFF
--- a/relay/schema/api_disable_schema.json
+++ b/relay/schema/api_disable_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_disablenow_schema.json
+++ b/relay/schema/api_disablenow_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_enable_schema.json
+++ b/relay/schema/api_enable_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_list_schema.json
+++ b/relay/schema/api_list_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_listall_schema.json
+++ b/relay/schema/api_listall_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_listbound_schema.json
+++ b/relay/schema/api_listbound_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",

--- a/relay/schema/api_status_schema.json
+++ b/relay/schema/api_status_schema.json
@@ -8,10 +8,7 @@
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": "string",
-                    "pattern": "^[0-9a-zA-Z ]+$",
-                    "minLength": 2,
-                    "maxLength": 64
+                    "type": "string"
                 },
                 "id": {
                     "type": "string",


### PR DESCRIPTION
This fixes the bug with the linux client of Teams, as it uses a name as "Last, First", while other clients use "First Last".

We determined that forcing a user's name to match a Regex was unimportant, so we've removed the pattern field from the individual schemas.

This will allow our code to operate in production with the Linux version of Teams.