### PR TITLE
Fixed usage message to properly display angle brackets on Teams clients

### DIFF
--- a/chatbot/features/lib/usage.js
+++ b/chatbot/features/lib/usage.js
@@ -14,23 +14,23 @@ const usage = {
         text: 'List all resources'
     },
     'listbound': {
-        comm: 'listbound <resource>',
+        comm: 'listbound \\<resource\\>',
         text: 'List all resources bound to another resource'
     },
     'status': {
-        comm: 'status <resource>',
+        comm: 'status \\<resource\\>',
         text: 'Display the status of a resource'
     },
     'enable': {
-        comm: 'enable <resource>',
+        comm: 'enable \\<resource\\>',
         text: 'Enable a resource by name'
     },
     'disable': {
-        comm: 'disable <resource> [delay: optional, default=0]',
+        comm: 'disable \\<resource\\> [delay: optional, default=0]',
         text: 'Disable a resource gently by name with an optional delay (seconds)'
     },
     'disablenow': {
-        comm: 'disablenow <resource> [delay: optional, default=0]',
+        comm: 'disablenow \\<resource\\> [delay: optional, default=0]',
         text: 'Disable a resource (non-gently) by name with an optional delay (seconds)'
     },
     'request-auth':  {


### PR DESCRIPTION
Unlike the Bot Framework Emulator, actual MS Teams clients require angle brackets to be prepended by a '\'. To do this within JS, all angle brackets in string form now have '\\' before them.

This will allow the usage message to display correctly in production.